### PR TITLE
enable patching for rendered manifests

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -47,6 +47,7 @@ var (
 		serviceCIDR         string
 		cloudProvider       string
 		networkProvider     string
+		patchDir            string
 	}
 
 	imageVersions = asset.DefaultImages
@@ -67,6 +68,7 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
 	cmdRender.Flags().StringVar(&renderOpts.networkProvider, "network-provider", "flannel", "CNI network provider (flannel or experimental-canal).")
+	cmdRender.Flags().StringVar(&renderOpts.patchDir, "patch-dir", "", "Output path for rendered assets")
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -79,7 +81,17 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if renderOpts.patchDir != "" {
+		patches, err := asset.ReadPatchDir(renderOpts.patchDir)
+		if err != nil {
+			return err
+		}
 
+		err = as.Patch(patches)
+		if err != nil {
+			return err
+		}
+	}
 	return as.WriteFiles(renderOpts.assetDir)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20191011121108-aa519ddbe484 // indirect
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
+	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/spec v0.19.4 // indirect
@@ -41,6 +41,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/kr/pty v1.1.8 // indirect
+	github.com/kubernetes-sigs/yaml v1.1.0
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo v1.10.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/emicklei/go-restful v2.11.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQm
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -191,6 +192,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubernetes-sigs/bootkube v0.14.0 h1:Ic1Pi+K3dGDxpPsNygSP4NsuIhHDx7SVJbHSlkdiWbY=
 github.com/kubernetes-sigs/bootkube v0.14.0/go.mod h1:S1oz0QOCDDrAYhj24SBOIdFC6Pj/idkUxRalnBPr6ts=
+github.com/kubernetes-sigs/yaml v1.1.0 h1:oqCjQSegsfZ2Lf9OutaFEeq5y6TrBSTuvPeJ6RKoNoU=
+github.com/kubernetes-sigs/yaml v1.1.0/go.mod h1:yDUYjn6Z3s4VTIBA3/+ua4UkMDkGYI0uelklrvZRs0E=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -194,8 +194,9 @@ func NewDefaultAssets(conf Config) (Assets, error) {
 }
 
 type Asset struct {
-	Name string
-	Data []byte
+	Name    string
+	Data    []byte
+	Matcher patchMatch
 }
 
 type Assets []Asset

--- a/pkg/asset/patch.go
+++ b/pkg/asset/patch.go
@@ -1,0 +1,132 @@
+package asset
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/ghodss/yaml"
+)
+
+type PatchJSON6902 struct {
+	// these fields specify the patch target resource
+	Group      string `yaml:"group"`
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	// Name and Namespace are optional
+	// NOTE: technically name is required now, but we default it elsewhere
+	// Third party users of this type / library would need to set it.
+	Metadata metadata `yaml:"metadata"`
+	// Patch should contain the contents of the json patch as a string
+	Patch     string `yaml:"patch"`
+	JsonPatch jsonpatch.Patch
+	Matcher   patchMatch
+}
+
+type patchMatch struct {
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Metadata   metadata
+}
+type metadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+func getMatchInfo(data []byte) (patchMatch, error) {
+	r := patchMatch{}
+	if err := yaml.Unmarshal(data, &r); err != nil {
+		return patchMatch{}, errors.New("Failed to parse metadata")
+	}
+	return r, nil
+}
+
+func (a *Asset) GenResourceMatchInfo() {
+	m, _ := getMatchInfo(a.Data)
+	a.Matcher = m
+}
+
+func ReadPatchDir(dir string) ([]PatchJSON6902, error) {
+	patches := []PatchJSON6902{}
+	patchfiles, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range patchfiles {
+		file, _ := ioutil.ReadFile(dir + "/" + f.Name())
+		p, err := ReadPatch(file)
+		if err != nil {
+			return nil, err
+		}
+		patches = append(patches, p)
+	}
+	return patches, nil
+}
+
+func ReadPatch(file []byte) (PatchJSON6902, error) {
+	p := PatchJSON6902{}
+	m, err := getMatchInfo(file)
+	if err = yaml.Unmarshal(file, &p); err != nil {
+		return PatchJSON6902{}, errors.New("Unable to parse patch metadata")
+	}
+	p.Matcher = m
+	p, err = convertJSON6902Patch(p)
+	if err != nil {
+		return PatchJSON6902{}, err
+	}
+	return p, nil
+}
+
+func (a *Asset) patch6902(patch PatchJSON6902) (match bool, err error) {
+	if !a.matches(patch.Matcher) {
+		return false, nil
+	}
+	aj, err := yaml.YAMLToJSON(a.Data)
+	if err != nil {
+		return true, err
+	}
+	patched, err := patch.JsonPatch.Apply(aj)
+	if err != nil {
+		fmt.Println(err)
+		return true, err
+	}
+	ay, err := yaml.JSONToYAML(patched)
+	if err != nil {
+		return true, err
+	}
+	a.Data = ay
+	return true, nil
+}
+
+// TBM to assets.go
+func (a Asset) matches(pm patchMatch) bool {
+	am := &a.Matcher
+	return am.Kind == pm.Kind && am.APIVersion == pm.APIVersion && am.Metadata.Name == pm.Metadata.Name
+}
+
+func convertJSON6902Patch(patch PatchJSON6902) (PatchJSON6902, error) {
+	patchJSON, err := yaml.YAMLToJSON([]byte(patch.Patch))
+	if err != nil {
+		return PatchJSON6902{}, err
+	}
+	jpatch, err := jsonpatch.DecodePatch(patchJSON)
+	if err != nil {
+		return PatchJSON6902{}, err
+	}
+	patch.JsonPatch = jpatch
+	return patch, nil
+}
+
+// TBM to assets.go
+func (as Assets) Patch(patches []PatchJSON6902) error {
+	for i, _ := range as {
+		as[i].GenResourceMatchInfo()
+		for _, p := range patches {
+			if _, err := as[i].patch6902(p); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/asset/patch_test.go
+++ b/pkg/asset/patch_test.go
@@ -1,0 +1,200 @@
+package asset
+
+import (
+	"testing"
+)
+
+func TestPatch(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		Name         string
+		As           Assets
+		P            []byte
+		ExpectError  bool
+		ExpectOutput string
+	}
+	cases := []testCase{
+		{
+			Name:         "test basic add to list",
+			As:           genAsset("testadd.yaml", []byte(testAddManifest)),
+			P:            testSimpleAddPatch,
+			ExpectError:  false,
+			ExpectOutput: resultSimpleAdd,
+		},
+		{
+			Name:         "test simple replace value",
+			As:           genAsset("testreplace.yaml", []byte(testReplaceManifest)),
+			P:            testSimpleReplacePatch,
+			ExpectError:  false,
+			ExpectOutput: resultSimpleReplace,
+		},
+		{
+			Name:         "test list replace value",
+			As:           genAsset("testreplace.yaml", []byte(testAddManifest)),
+			P:            testListReplacePatch,
+			ExpectError:  false,
+			ExpectOutput: resultListReplace,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ps, _ := ReadPatch(tc.P)
+			err := tc.As.Patch([]PatchJSON6902{ps})
+			ExpectError(t, tc.ExpectError, err)
+			if err == nil {
+				StringEqual(t, tc.ExpectOutput, string(tc.As[0].Data))
+			}
+		})
+	}
+}
+
+func genAsset(name string, data []byte) []Asset {
+	testAsset := Asset{
+		Name: name,
+		Data: data,
+	}
+	return []Asset{testAsset}
+}
+
+const testAddManifest = `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - ./hyperkube
+        - kube-proxy
+        - --cluster-cidr=10.2.0.0/16
+        - --hostname-override=$(NODE_NAME)
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --proxy-mode=iptables
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+`
+const testReplaceManifest = `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+`
+
+var testSimpleAddPatch = []byte(`
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+patch: |
+  - op: add
+    path: /spec/template/spec/containers/0/command/-
+    value: --test
+`)
+
+var testSimpleReplacePatch = []byte(`
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+patch: |
+  - op: replace
+    path: /spec/updateStrategy/rollingUpdate/maxUnavailable
+    value: 2
+`)
+
+var testListReplacePatch = []byte(`
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+patch: |
+  - op: replace
+    path: /spec/template/spec/containers/0/command/5
+    value: --proxy-mode=ipvs
+`)
+
+const resultSimpleAdd = `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - ./hyperkube
+        - kube-proxy
+        - --cluster-cidr=10.2.0.0/16
+        - --hostname-override=$(NODE_NAME)
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --proxy-mode=iptables
+        - --test
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+`
+
+const resultSimpleReplace = `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 2
+    type: RollingUpdate
+`
+
+const resultListReplace = `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - ./hyperkube
+        - kube-proxy
+        - --cluster-cidr=10.2.0.0/16
+        - --hostname-override=$(NODE_NAME)
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --proxy-mode=ipvs
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+`
+
+type testingDotT interface {
+	Errorf(format string, args ...interface{})
+}
+
+func ExpectError(t testingDotT, expectError bool, err error) {
+	if err != nil && !expectError {
+		t.Errorf("Did not expect error: %v", err)
+	}
+	if err == nil && expectError {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+func StringEqual(t testingDotT, expected, result string) {
+	if expected != result {
+		t.Errorf("Strings did not match!")
+		t.Errorf("Expected: %q", expected)
+		t.Errorf("But got: %q", result)
+	}
+}


### PR DESCRIPTION
The idea is to allow a limited level of patching of the rednered output which is static
There are two levels of users for bootkube
1) Brings their own manifests
2) Uses the manifests available 

This feature is to bridge the gap between both so that if someone needs a change they do not need to go to option 1 but is able to patch the available resource. 

there are examples of patching in the test cases, but more robust examples will be made available , the current code does a simple match with the apiVersion/kind/metadata.name and then proceeds with a normal jsonpatch