### PR TITLE
Enables Kubelet Auth

### DIFF
--- a/hack/multi-node/bootkube-up
+++ b/hack/multi-node/bootkube-up
@@ -26,7 +26,7 @@ if [ ! -d "cluster" ]; then
   cp user-data.sample cluster/user-data-worker
   cp user-data.sample cluster/user-data-controller
   sed -i -e '/node.kubernetes.io\/master/d' cluster/user-data-worker
-  sed -i '' -e 's/node-role.kubernetes.io\/master/node.kubernetes.io\/master/g' cluster/manifests/*
+  sed -i -e 's/node-role.kubernetes.io\/master/node.kubernetes.io\/master/g' cluster/manifests/*
 fi
 
 # Start the VM

--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -30,6 +30,8 @@ coreos:
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --anonymous-auth=false \
+          --authentication-token-webhook \
+          --authorization-mode=Webhook \
           --cert-dir=/var/lib/kubelet/pki \
           --client-ca-file=/etc/kubernetes/ca.crt \
           --cluster_dns=10.3.0.10 \

--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -22,6 +22,7 @@ if [ ! -d "cluster" ]; then
   ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:6443 ${cnp_render_flags}
   cp user-data.sample cluster/user-data
   cat user-data-etcd.sample >> cluster/user-data
+  sed -i -e 's/node-role.kubernetes.io\/master/node.kubernetes.io\/master/g' cluster/manifests/*
 fi
 
 # Start the VM

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -30,6 +30,8 @@ coreos:
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --anonymous-auth=false \
+          --authentication-token-webhook \
+          --authorization-mode=Webhook \
           --cert-dir=/var/lib/kubelet/pki \
           --client-ca-file=/etc/kubernetes/ca.crt \
           --cluster_dns=10.3.0.10 \

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -35,6 +35,8 @@ const (
 	AssetPathFrontProxyClientKey            = "tls/front-proxy-client.key"
 	AssetPathServiceAccountPrivKey          = "tls/service-account.key"
 	AssetPathServiceAccountPubKey           = "tls/service-account.pub"
+	AssetPathKubeletClientCert              = "tls/apiserver-kubelet-client.crt"
+	AssetPathKubeletClientKey               = "tls/apiserver-kubelet-client.key"
 	AssetPathAdminKey                       = "tls/admin.key"
 	AssetPathAdminCert                      = "tls/admin.crt"
 	AssetPathAdminKubeConfig                = "auth/kubeconfig"

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -170,8 +170,8 @@ spec:
 {{- end }}
         - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}
         - --insecure-port=0
-        - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
-        - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
+        - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver-kubelet-client.crt
+        - --kubelet-client-key=/etc/kubernetes/secrets/apiserver-kubelet-client.key
         - --secure-port={{ (index .APIServers 0).Port }}
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --service-cluster-ip-range={{ .ServiceCIDR }}
@@ -244,8 +244,8 @@ spec:
     - --etcd-keyfile=/etc/kubernetes/secrets/etcd-client.key
 {{- end }}
     - --etcd-servers={{ range $i, $e := .EtcdServers }}{{ if $i }},{{end}}{{ $e }}{{end}}
-    - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
-    - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
+    - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver-kubelet-client.crt
+    - --kubelet-client-key=/etc/kubernetes/secrets/apiserver-kubelet-client.key
     - --secure-port={{ (index .APIServers 0).Port }}
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
     - --service-cluster-ip-range={{ .ServiceCIDR }}

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -198,6 +198,8 @@ func newAPIServerSecretAsset(assets Assets, etcdUseTLS bool) (Asset, error) {
 		AssetPathAggregatorCA,
 		AssetPathFrontProxyClientCert,
 		AssetPathFrontProxyClientKey,
+		AssetPathKubeletClientCert,
+		AssetPathKubeletClientKey,
 		AssetPathCACert,
 	}
 	if etcdUseTLS {

--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -11,6 +11,10 @@ import (
 	"github.com/kubernetes-sigs/bootkube/pkg/tlsutil"
 )
 
+// TLS organizations map to Kubernetes groups, and "system:masters"
+// is a well-known Kubernetes group that gives a user admin power.
+const orgSystemMasters = "system:masters"
+
 func newTLSAssets(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey, altNames tlsutil.AltNames) ([]Asset, error) {
 	var (
 		assets []Asset
@@ -115,7 +119,7 @@ func newAPIKeyAndCert(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey, altNa
 
 	config := tlsutil.CertConfig{
 		CommonName:   "kube-apiserver",
-		Organization: []string{"kube-master"},
+		Organization: []string{orgSystemMasters},
 		AltNames:     altNames,
 	}
 	cert, err := tlsutil.NewSignedCertificate(config, key, caCert, caPrivKey)
@@ -126,9 +130,6 @@ func newAPIKeyAndCert(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey, altNa
 }
 
 func newAdminKeyAndCert(caCert *x509.Certificate, caPrivKey *rsa.PrivateKey) (*rsa.PrivateKey, *x509.Certificate, error) {
-	// TLS organizations map to Kubernetes groups, and "system:masters"
-	// is a well-known Kubernetes group that gives a user admin power.
-	const orgSystemMasters = "system:masters"
 
 	key, err := tlsutil.NewPrivateKey()
 	if err != nil {


### PR DESCRIPTION
* Changes api-server cert org to system:masters
* This allows the api-server to maintain admin access and also ensure that kubectl logs/exec etc remain functional 
* Changes to `hack/*` to move the kubelet from `AllwaysAllow` to `WebHook`authn mode
* Fixes broken `sed` command. 