### PR TITLE
CoreDNS Updates

### DIFF
--- a/pkg/asset/images.go
+++ b/pkg/asset/images.go
@@ -7,7 +7,7 @@ var DefaultImages = ImageVersions{
 	FlannelCNI:      "quay.io/coreos/flannel-cni:v0.3.0",
 	Calico:          "quay.io/calico/node:v3.0.3",
 	CalicoCNI:       "quay.io/calico/cni:v2.0.0",
-	CoreDNS:         "k8s.gcr.io/coredns:1.6.2",
+	CoreDNS:         "k8s.gcr.io/coredns:1.6.5",
 	Hyperkube:       "k8s.gcr.io/hyperkube:v1.16.2",
 	PodCheckpointer: "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1",
 }


### PR DESCRIPTION
- Adds Pod Anti Affinity
- Updates replicas to 2
- Adds lameduck plugin to health ( it allows 5 seconds wait time after its unhealthy to shutdown )
- Fixes Labels kube-dns to coredns
- Adds Readiness Probe
- Updates CoreDNS to 1.6.5