### PR TITLE
feat: add cluster name to configs and create context name

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -47,6 +47,7 @@ var (
 		serviceCIDR         string
 		cloudProvider       string
 		networkProvider     string
+		clusterName         string
 	}
 
 	imageVersions = asset.DefaultImages
@@ -67,6 +68,8 @@ func init() {
 	cmdRender.Flags().StringVar(&renderOpts.serviceCIDR, "service-cidr", "10.3.0.0/24", "The CIDR range of cluster services.")
 	cmdRender.Flags().StringVar(&renderOpts.cloudProvider, "cloud-provider", "", "The provider for cloud services.  Empty string for no provider")
 	cmdRender.Flags().StringVar(&renderOpts.networkProvider, "network-provider", "flannel", "CNI network provider (flannel, experimental-canal or experimental-calico).")
+	cmdRender.Flags().StringVar(&renderOpts.clusterName, "cluster-name", "", "The name of the kubernetes cluster.")
+
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
@@ -189,6 +192,7 @@ func flagsToAssetConfig() (c *asset.Config, err error) {
 	}
 
 	return &asset.Config{
+		ClusterName:     renderOpts.clusterName,
 		EtcdCACert:      etcdCACert,
 		EtcdClientCert:  etcdClientCert,
 		EtcdClientKey:   etcdClientKey,

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -108,6 +108,7 @@ var (
 // AssetConfig holds all configuration needed when generating
 // the default set of assets.
 type Config struct {
+	ClusterName            string
 	EtcdCACert             *x509.Certificate
 	EtcdClientCert         *x509.Certificate
 	EtcdClientKey          *rsa.PrivateKey

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -4,7 +4,7 @@ package internal
 var AdminKubeConfigTemplate = []byte(`apiVersion: v1
 kind: Config
 clusters:
-- name: local
+- name: {{ or .Cluster "local" }}
   cluster:
     server: {{ .Server }}
     certificate-authority-data: {{ .CACert }}
@@ -15,8 +15,10 @@ users:
     client-key-data: {{ .AdminKey }}
 contexts:
 - context:
-    cluster: local
+    cluster: {{ or .Cluster "local" }}
     user: admin
+  name: admin@{{ or .Cluster "local" }}
+current-context: admin@{{ or .Cluster "local" }}
 `)
 
 var KubeletKubeConfigTemplate = []byte(`apiVersion: v1

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -156,6 +156,7 @@ func newKubeConfigAssets(assets Assets, conf Config) ([]Asset, error) {
 	}
 
 	cfg := struct {
+		Cluster              string
 		Server               string
 		CACert               string
 		AdminCert            string
@@ -164,6 +165,7 @@ func newKubeConfigAssets(assets Assets, conf Config) ([]Asset, error) {
 		BootstrapTokenSecret string
 	}{
 		Server:               conf.APIServers[0].String(),
+		Cluster:              conf.ClusterName,
 		CACert:               base64.StdEncoding.EncodeToString(caCert.Data),
 		AdminCert:            base64.StdEncoding.EncodeToString(adminCert.Data),
 		AdminKey:             base64.StdEncoding.EncodeToString(adminKey.Data),


### PR DESCRIPTION
This PR adds a ClusterName value to the bootkube config struct, an
optional flag to bootkube render,  as well
as using any specified value to create a context name in the kubeconfig file.
This allows tools like [kconf](https://github.com/particledecay/kconf) to merge various bootkube-created
kubeconfigs

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>