### PR TITLE
Remove dghubble from OWNERS list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@
 
 approvers:
   - aaronlevy
-  - dghubble
   - rphillips
   - rmenn
   - andrewrynhard 


### PR DESCRIPTION
Hey folks, for my own clusters, I no longer use bootkube and haven't for a while. Its been a good few years, but I think its best I take myself off the list and leave it in the capable hands of those who are actively using it.