### PR TITLE
Add support for multiple Pod and Service subnets

### DIFF
--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -1,0 +1,91 @@
+package asset
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestJoinStringsFromSliceOrSingle(t *testing.T) {
+	var out string
+	testSingle := "hello"
+	testSlice := []string{"Hello", "World"}
+
+	if out = joinStringsFromSliceOrSingle(nil, testSingle); out != testSingle {
+		t.Errorf("single-only test failed: expected '%s', got '%s'", testSingle, out)
+	}
+
+	if out = joinStringsFromSliceOrSingle(testSlice, ""); out != strings.Join(testSlice, ",") {
+		t.Errorf("slice-only test failed: expected '%s', got '%s'", strings.Join(testSlice, ","), out)
+	}
+
+	if out = joinStringsFromSliceOrSingle(testSlice, testSingle); out != strings.Join(testSlice, ",") {
+		t.Errorf("single+slice test failed: expected '%s', got '%s'", strings.Join(testSlice, ","), out)
+	}
+
+	if out = joinStringsFromSliceOrSingle(nil, ""); out != "" {
+		t.Errorf("empty test failed: expected '%s', got '%s'", "", out)
+	}
+}
+
+func TestContainsNonLocalIPv6(t *testing.T) {
+	ipv4Loopback := net.ParseIP("127.0.0.1")
+	ipv4PublicUnicast := net.ParseIP("8.8.8.8")
+	ipv4PrivateUnicast := net.ParseIP("192.168.1.2")
+	ipv4Multicast := net.ParseIP("224.10.20.30")
+
+	ipv6Loopback := net.ParseIP("::1")
+	ipv6Unicast := net.ParseIP("2001:db8::1")
+	ipv6LinkLocal := net.ParseIP("fe80::db8:2")
+	ipv6Multicast := net.ParseIP("ff00::db8:3")
+
+	if containsNonLocalIPv6(nil) {
+		t.Errorf("empty set failed")
+	}
+	if containsNonLocalIPv6([]net.IP{ipv4Loopback, ipv4PublicUnicast, ipv4PrivateUnicast, ipv4Multicast, ipv6Loopback}) {
+		t.Errorf("all-false set check failed")
+	}
+	if !containsNonLocalIPv6([]net.IP{ipv6Unicast}) {
+		t.Errorf("single-true set failed")
+	}
+	if !containsNonLocalIPv6([]net.IP{ipv6LinkLocal, ipv4Loopback}) {
+		t.Errorf("true+v4Loop set failed")
+	}
+	if !containsNonLocalIPv6([]net.IP{ipv6Loopback, ipv6Multicast}) {
+		t.Errorf("true+v6Loop set failed")
+	}
+}
+
+func TestStringerSlice(t *testing.T) {
+	var out []string
+
+	if out = stringerSlice(nil); out != nil {
+		t.Errorf("nil input test did not have nil output: %v", out)
+	}
+
+	testNilSlice := []net.IP{}
+	out = stringerSlice(testNilSlice)
+	if len(out) != len(testNilSlice) {
+		t.Errorf("output mismatch (%d) for testNilSlice (%d)", len(out), len(testNilSlice))
+	}
+
+	testNonStringerSlice := []int{1, 2, 3, 4}
+	out = stringerSlice(testNonStringerSlice)
+	for i, s := range out {
+		if s != "" {
+			t.Errorf("nonStringerSlice[%d] produced non-nil output: %s", i, s)
+		}
+	}
+
+	testNormal1 := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("0.0.0.0")}
+	out = stringerSlice(testNormal1)
+	if len(out) != len(testNormal1) {
+		t.Errorf("output mismatch (%d) for testNormal1 (%d)", len(out), len(testNormal1))
+	}
+	if out[0] != testNormal1[0].String() {
+		t.Errorf("output index 0 mismatch (%s) on testNormal (%s)", out[0], testNormal1[0].String())
+	}
+	if out[1] != testNormal1[1].String() {
+		t.Errorf("output index 1 mismatch (%s) on testNormal (%s)", out[1], testNormal1[1].String())
+	}
+}

--- a/pkg/asset/internal/templates.go
+++ b/pkg/asset/internal/templates.go
@@ -154,7 +154,7 @@ spec:
         - --allow-privileged=true
         - --anonymous-auth=false
         - --authorization-mode=Node,RBAC
-        - --bind-address=0.0.0.0
+        - --bind-address={{ .BindAllAddress }}
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
         - --requestheader-client-ca-file=/etc/kubernetes/secrets/front-proxy-ca.crt
         - --requestheader-allowed-names=front-proxy-client
@@ -176,7 +176,7 @@ spec:
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver-kubelet-client.key
         - --secure-port={{ (index .APIServers 0).Port }}
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
-        - --service-cluster-ip-range={{ .ServiceCIDR }}
+        - --service-cluster-ip-range={{ .ServiceCIDRsString }}
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         env:
@@ -229,7 +229,7 @@ spec:
     - --advertise-address=$(POD_IP)
     - --allow-privileged=true
     - --authorization-mode=Node,RBAC
-    - --bind-address=0.0.0.0
+    - --bind-address={{ .BindAllAddress }}
     - --client-ca-file=/etc/kubernetes/secrets/ca.crt
     - --requestheader-client-ca-file=/etc/kubernetes/secrets/front-proxy-ca.crt
     - --requestheader-allowed-names=front-proxy-client
@@ -250,7 +250,7 @@ spec:
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver-kubelet-client.key
     - --secure-port={{ (index .APIServers 0).Port }}
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
-    - --service-cluster-ip-range={{ .ServiceCIDR }}
+    - --service-cluster-ip-range={{ .ServiceCIDRsString }}
     - --cloud-provider={{ .CloudProvider }}
     - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
     - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
@@ -456,8 +456,8 @@ spec:
         - --use-service-account-credentials
         - --allocate-node-cidrs=true
         - --cloud-provider={{ .CloudProvider }}
-        - --cluster-cidr={{ .PodCIDR }}
-        - --service-cluster-ip-range={{ .ServiceCIDR }}
+        - --cluster-cidr={{ .PodCIDRsString }}
+        - --service-cluster-ip-range={{ .ServiceCIDRsString }}
         - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
         - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
         - --configure-cloud-routes=false
@@ -535,8 +535,8 @@ spec:
     - ./hyperkube
     - kube-controller-manager
     - --allocate-node-cidrs=true
-    - --cluster-cidr={{ .PodCIDR }}
-    - --service-cluster-ip-range={{ .ServiceCIDR }}
+    - --cluster-cidr={{ .PodCIDRsString }}
+    - --service-cluster-ip-range={{ .ServiceCIDRsString }}
     - --cloud-provider={{ .CloudProvider }}
     - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
     - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
@@ -698,7 +698,7 @@ spec:
         command:
         - ./hyperkube
         - kube-proxy
-        - --cluster-cidr={{ .PodCIDR }}
+        - --cluster-cidr={{ .PodCIDRsString }}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
         - --proxy-mode=iptables
@@ -987,7 +987,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: {{ .DNSServiceIP }}
+  clusterIP: {{ index .DNSServiceIPsString 0 }}
   ports:
     - name: dns
       port: 53


### PR DESCRIPTION
Adds dual stack (IPv4 + IPv6) support for:
  - Service subnets
  - Pod subnets
  - API service
  - DNS service

Ref issue #1079

Signed-off-by: Seán C McCord <ulexus@gmail.com>