### PR TITLE
pkg/bootkube: fix no newline in output while waiting for the CRDs

### DIFF
--- a/pkg/bootkube/create.go
+++ b/pkg/bootkube/create.go
@@ -201,7 +201,7 @@ func (c *creater) createManifests(manifests []manifest) (ok bool) {
 	for _, crd := range crds {
 		if err := c.waitForCRD(crd); err != nil {
 			ok = false
-			UserOutput("Failed waiting for %s: %v", crd, err)
+			UserOutput("Failed waiting for %s: %v\n", crd, err)
 			if c.strict {
 				return false
 			}


### PR DESCRIPTION
Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>